### PR TITLE
added outtmpl to properly name output files

### DIFF
--- a/spotify_to_mp3.py
+++ b/spotify_to_mp3.py
@@ -80,6 +80,7 @@ def find_and_download_songs(reference_file: str):
                     'preferredcodec': 'mp3',
                     'preferredquality': '192',
                 }],
+                'outtmpl': os.path.join( "{}".format(os.getcwd()), '%(title)s.%(ext)s'),
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([best_url])


### PR DESCRIPTION
This change fixes the [video id] from being added to the output files.
BEFORE: Haru [r3UY3-laVzQ].mp3
AFTER: Haru.mp3